### PR TITLE
Makes logging into a conditional option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,19 @@ bean-serial
 
 Virtual serial device using ble-bean (Lightblue Bean node bindings)
 
+## How To Use
 
+```javascript
+var Bean = require("ble-bean");
+var SerialPort = require("bean-serial").SerialPort;
+
+var serialPort ;
+var options = {
+	logging: true // default to false
+};
+
+Bean.discover(function(bean) {
+	serialPort = new SerialPort(bean, options);
+	// now just use as "normal" serial connection
+}
+```

--- a/index.js
+++ b/index.js
@@ -6,8 +6,10 @@ var stream = require('stream');
 
 function BeanSerialPort(bean, options) {
 
+  var opts = options || {};
   var self = this;
   self.bean = bean;
+  self.logging = (opts.logging || false);
 
   bean.on("serial", function(data, valid, seq, size){
     self.emit('data', data);
@@ -50,26 +52,29 @@ BeanSerialPort.prototype.write = function (data, callback) {
 
   self.bean.write(data,callback);
 
-  console.log('writing buffer:', data);
+  if (self.logging) { console.log('writing buffer:', data); }
 
 };
 
 BeanSerialPort.prototype.close = function (callback) {
-  console.log('closing');
+  if (self.logging) { console.log('closing'); }
+
   if(callback){
     callback();
   }
 };
 
 BeanSerialPort.prototype.flush = function (callback) {
-  console.log('flush');
+  if (self.logging) { console.log('flush'); }
+
   if(callback){
     callback();
   }
 };
 
 BeanSerialPort.prototype.drain = function (callback) {
-  console.log('drain');
+  if (self.logging) { console.log('drain'); }
+
   if(callback){
     callback();
   }


### PR DESCRIPTION
This pull request adds a new option `logging` to make all of the `console.log` calls conditional. 

```
var options = {
  logging: true // default to false
};

Bean.discover(function(bean) {
  serialPort = new SerialPort(bean, options);
  // now just use as "normal" serial connection
}
```

The default is `false` to reduce the amount of log chatter.